### PR TITLE
Allow debugging dead code

### DIFF
--- a/codegen/packages/rust/src/visitors/provider-visitor.ts
+++ b/codegen/packages/rust/src/visitors/provider-visitor.ts
@@ -166,7 +166,7 @@ pub(crate) fn ${name}(
   let op_id_bytes = ${indexConstant}_INDEX_BYTES.as_slice();
   let payload = match wasmrs_guest::serialize(&inputs) {
       Ok(bytes) => Payload::new([op_id_bytes, &[0, 0, 0, 0]].concat().into(), bytes.into()),
-      Err(e) => unreachable!(),
+      Err(_) => unreachable!(),
   };
   Host::default().request_stream(payload).map(|result| {
       result

--- a/rust/crates/embedded-msgpack/src/decode/mod.rs
+++ b/rust/crates/embedded-msgpack/src/decode/mod.rs
@@ -456,7 +456,7 @@ pub fn read_str(buf: &[u8]) -> Result<(&str, usize), Error> {
                 return Err(Error::EndOfBuffer);
             }
         }
-        x => return Err(Error::InvalidStringType),
+        _ => return Err(Error::InvalidStringType),
     };
     let buf = &buf[header_len..header_len + len];
     let s = if buf.is_ascii() {

--- a/rust/crates/embedded-msgpack/src/decode/serde/mod.rs
+++ b/rust/crates/embedded-msgpack/src/decode/serde/mod.rs
@@ -14,6 +14,7 @@ use super::Error;
 type Result<T> = core::result::Result<T, Error>;
 
 #[cfg(test)]
+#[allow(dead_code)]
 fn print_debug<T>(prefix: &str, function_name: &str, de: &Deserializer) {
     #[cfg(not(feature = "std"))]
     extern crate std;
@@ -29,6 +30,7 @@ fn print_debug<T>(prefix: &str, function_name: &str, de: &Deserializer) {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 fn print_debug_value<T, V: core::fmt::Debug>(function_name: &str, de: &Deserializer, value: &V) {
     #[cfg(not(feature = "std"))]
     extern crate std;
@@ -43,8 +45,10 @@ fn print_debug_value<T, V: core::fmt::Debug>(function_name: &str, de: &Deseriali
     );
 }
 #[cfg(not(test))]
+#[allow(dead_code)]
 fn print_debug<T>(_prefix: &str, _function_name: &str, _de: &Deserializer) {}
 #[cfg(not(test))]
+#[allow(dead_code)]
 fn print_debug_value<T, V: core::fmt::Debug>(_function_name: &str, _de: &Deserializer, _value: &V) {}
 
 pub(crate) struct Deserializer<'b> {


### PR DESCRIPTION
Removes redundant warnings