### PR TITLE
fix: Rename an old visitRole to visitInterface

### DIFF
--- a/codegen/packages/bus/src/bus_visitor.ts
+++ b/codegen/packages/bus/src/bus_visitor.ts
@@ -108,7 +108,7 @@ services:\n`);
 }
 
 class ServicesVisitor extends BaseVisitor {
-  visitRole(context: Context): void {
+  visitInterface(context: Context): void {
     if (!isService(context)) {
       return;
     }


### PR DESCRIPTION
BusVisitor was not emitting the service name in the stubbed out YAML.

This PR fixes that by renaming an old `visitRole` method to `visitInterface`. Apex recently renamed `role` to `interface` for clarity.