### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/rodaine/table v1.0.1
 	github.com/stretchr/testify v1.8.1
 	github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a
-	github.com/tetratelabs/wazero v1.0.0-pre.3
+	github.com/tetratelabs/wazero v1.0.0-pre.4
 	golang.org/x/exp v0.0.0-20221025133541-111beb427cde
 )
 

--- a/go/go.sum
+++ b/go/go.sum
@@ -24,8 +24,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a h1:P0R3+CTAT7daT8ig5gh9GEd/eDQ5md1xl4pkYMcwOqg=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 golang.org/x/exp v0.0.0-20221025133541-111beb427cde h1:21I041MHkLEAgTE3ziMHbCknpoSjQKUmXhIDgfpGiUo=
 golang.org/x/exp v0.0.0-20221025133541-111beb427cde/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go/transport/wasmrs/cmd/wasmrs/go.mod
+++ b/go/transport/wasmrs/cmd/wasmrs/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/mattn/go-colorable v0.1.9 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/rodaine/table v1.0.1 // indirect
-	github.com/tetratelabs/wazero v1.0.0-pre.3 // indirect
+	github.com/tetratelabs/wazero v1.0.0-pre.4 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/exp v0.0.0-20221025133541-111beb427cde // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect

--- a/go/transport/wasmrs/cmd/wasmrs/go.sum
+++ b/go/transport/wasmrs/cmd/wasmrs/go.sum
@@ -22,8 +22,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/go/transport/wasmrs/host/host.go
+++ b/go/transport/wasmrs/host/host.go
@@ -88,7 +88,7 @@ func instantiateWasmrs(ctx context.Context, r wazero.Runtime) (api.Closer, error
 }
 
 // initBuffers is defined as an api.GoFunc for better performance vs reflection.
-func initBuffers(ctx context.Context, params []uint64) (_ []uint64) {
+func initBuffers(ctx context.Context, params []uint64) {
 	sendPtr, recvPtr := uint32(params[0]), uint32(params[1])
 
 	i := ctx.Value(instanceKey{}).(*Instance)
@@ -98,7 +98,7 @@ func initBuffers(ctx context.Context, params []uint64) (_ []uint64) {
 }
 
 // opList is defined as an api.GoFunc for better performance vs reflection.
-func opList(ctx context.Context, params []uint64) (_ []uint64) {
+func opList(ctx context.Context, params []uint64) {
 	opPtr, opSize := uint32(params[0]), uint32(params[1])
 
 	i := ctx.Value(instanceKey{}).(*Instance)
@@ -108,7 +108,7 @@ func opList(ctx context.Context, params []uint64) (_ []uint64) {
 }
 
 // send is defined as an api.GoFunc for better performance vs reflection.
-func send(ctx context.Context, params []uint64) (_ []uint64) {
+func send(ctx context.Context, params []uint64) {
 	recvPos := uint32(params[0])
 
 	i := ctx.Value(instanceKey{}).(*Instance)


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API
