### PR TITLE
Updated rust template and rust test bins to be installable via cargo

### DIFF
--- a/rust/bins/ops/Cargo.toml
+++ b/rust/bins/ops/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ops"
+name = "wasmrs-ops"
 version = "0.1.0"
 edition = "2021"
 description = "Print wasmRS operations from a .wasm file."

--- a/rust/bins/request/Cargo.toml
+++ b/rust/bins/request/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "request"
+name = "wasmrs-request"
 version = "0.1.0"
 edition = "2021"
 description = "Make a request to a wasmRS .wasm file."

--- a/templates/rust/Cargo.toml.tmpl
+++ b/templates/rust/Cargo.toml.tmpl
@@ -15,7 +15,7 @@ opt-level = "z"
 panic = "abort"
 
 [dependencies]
-wasmrs-guest = "0.1"
+wasmrs-guest = "0.2"
 thiserror = "1.0"
 serde = { version = "1", default-features = false, features = ["derive"] }
 async-trait = "0.1"


### PR DESCRIPTION
This PR:
- Updates template to use wasmrs `0.2`
- Changes the name of the `request` and `ops` test binaries to `wasmrs-request` and `wasmrs-ops` so I can publish and install them via `cargo`